### PR TITLE
生成Vector viewport宽高有误

### DIFF
--- a/svg-generator/src/main/java/com/github/megatronking/svg/generator/svg/parser/attribute/SvgAttributeParser.java
+++ b/svg-generator/src/main/java/com/github/megatronking/svg/generator/svg/parser/attribute/SvgAttributeParser.java
@@ -57,14 +57,10 @@ public class SvgAttributeParser extends SvgNodeAbstractAttributeParser<Svg> {
         } else {
             svg.viewBox = new float[4];
         }
-        if (svg.w != 0) {
-            svg.viewBox[2] = svg.w;
-        } else {
+        if (svg.w == 0) {
             svg.w = svg.viewBox[2];
         }
-        if (svg.h != 0) {
-            svg.viewBox[3] = svg.h;
-        } else {
+        if (svg.h == 0) {
             svg.h = svg.viewBox[3];
         }
     }


### PR DESCRIPTION
> **问题说明**
>在使用  _[阿里巴巴矢量图标库](http://www.iconfont.cn)_ 下载的`SVG`文件时,转换的`vector`中`viewport`宽高会被覆盖,导致可视区的宽高不准确,无法正常显示

> **修改说明**
>不对`viewport`进行宽高覆盖

> 示例
>比如在 _[阿里巴巴矢量图标库](http://www.iconfont.cn)_ 中下载一个`搜索`图标,下载`SVG`格式文件后,使用`SVG-Android`进行转换
>
>**当前转换结果如下(部分)**:
> `android:width="48dp"`
>  `android:height="48dp"`
> ` android:viewportHeight="48"`
> ` android:viewportWidth="48"`
>
>**期望转换结果为:**
> `android:width="48dp"`
>  `android:height="48dp"`
> ` android:viewportHeight="1024"`
> ` android:viewportWidth="1024"`

> **其他说明**
>修改后,对 `SVG-Android/svg-sample` 中`SVG`图片进行测试,测试正常,可以正常转换
>使用现有版本,转换后,完全可以手动改正过来,只是感觉手动去改太麻烦,还容易出错,所以才有这个pull